### PR TITLE
Update bottomNav.dart

### DIFF
--- a/lib/bottomNav.dart
+++ b/lib/bottomNav.dart
@@ -16,7 +16,7 @@ class BottomNavBar extends StatefulWidget {
 class _BottomNavBarState extends State<BottomNavBar> {
   int index=0;
   final screens=[
-    const homePage(),
+    const HomePage(),
      const QrScanner(),
     const ProfilePage()
   ];


### PR DESCRIPTION
The class names should follow `UpperCamelCase` convention in Dart. In your `screens` list, you have:

```bash
const homePage(),
```

Change `homePage` to `HomePage`:

```bash
const HomePage(),
```